### PR TITLE
feat: add default preset option for run command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,8 +29,8 @@ pub struct Cli {
 pub enum Commands {
     /// Run Claude Code with a specific preset
     Run {
-        /// Preset name to use
-        preset: String,
+        /// Preset name to use (defaults to "default" preset if available)
+        preset: Option<String>,
 
         #[command(flatten)]
         scope: ScopeArgs,

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -4,15 +4,37 @@ use crate::preset::resolver;
 use anyhow::{Context, Result};
 use std::process::{Command, ExitCode};
 
-pub fn run(preset_name: &str, scope: Scope, claude_args: &[String]) -> Result<ExitCode> {
-    let preset_path = loader::find_preset_scoped(preset_name, scope)
-        .with_context(|| format!("Could not find preset: {}", preset_name))?;
+pub fn run(preset_name: Option<&str>, scope: Scope, claude_args: &[String]) -> Result<ExitCode> {
+    // Determine which preset to use
+    let preset_to_use = match preset_name {
+        Some(name) => {
+            eprintln!("using preset <{}>", name);
+            name
+        }
+        None => {
+            // Try to find "default" preset
+            match loader::find_preset_scoped("default", scope) {
+                Ok(_) => {
+                    eprintln!("using preset <default>");
+                    "default"
+                }
+                Err(_) => {
+                    // No default preset found - run claude directly
+                    eprintln!("no preset found, falling back to: claude");
+                    return run_claude_directly(claude_args);
+                }
+            }
+        }
+    };
+
+    let preset_path = loader::find_preset_scoped(preset_to_use, scope)
+        .with_context(|| format!("Could not find preset: {}", preset_to_use))?;
 
     let preset = loader::load_preset(&preset_path)
-        .with_context(|| format!("Could not load preset: {}", preset_name))?;
+        .with_context(|| format!("Could not load preset: {}", preset_to_use))?;
 
     let resolved = resolver::resolve_inheritance(&preset)
-        .with_context(|| format!("Could not resolve preset: {}", preset_name))?;
+        .with_context(|| format!("Could not resolve preset: {}", preset_to_use))?;
 
     let mut cmd = Command::new("claude");
 
@@ -33,6 +55,18 @@ pub fn run(preset_name: &str, scope: Scope, claude_args: &[String]) -> Result<Ex
     }
 
     let status = cmd.status()?;
+    let code = status.code().unwrap_or(1);
+    Ok(ExitCode::from(code.clamp(0, 255) as u8))
+}
+
+fn run_claude_directly(claude_args: &[String]) -> Result<ExitCode> {
+    let mut cmd = Command::new("claude");
+    cmd.args(claude_args);
+
+    let status = cmd
+        .status()
+        .with_context(|| "Failed to execute claude command")?;
+
     let code = status.code().unwrap_or(1);
     Ok(ExitCode::from(code.clamp(0, 255) as u8))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ fn run(cli: Cli) -> Result<ExitCode> {
             preset,
             scope,
             claude_args,
-        } => claudio::commands::run::run(preset, scope.scope, claude_args)?,
+        } => claudio::commands::run::run(preset.as_deref(), scope.scope, claude_args)?,
         Commands::List {
             scope,
             name,


### PR DESCRIPTION
## Summary

Implements optional preset argument for `claudio run` command with intelligent fallback behavior.

## Changes

- **CLI (`src/cli.rs`)**: Made `preset` argument optional (`Option<String>`)
- **Run command (`src/commands/run.rs`)**: 
  - Updated signature to accept `Option<&str>`
  - Added default preset lookup logic
  - Added `run_claude_directly()` fallback function
  - Implemented user feedback messages
- **Main dispatcher (`src/main.rs`)**: Updated to handle `Option<String>` with `as_deref()`

## Behavior

### With explicit preset
```bash
$ claudio run my-preset
using preset <my-preset>
```

### With default preset (when `default.json` exists)
```bash
$ claudio run
using preset <default>
```

### Without any preset (fallback)
```bash
$ claudio run
no preset found, falling back to: claude
```

## Testing

- ✅ Code compiles successfully
- ✅ Help text shows optional preset argument
- ✅ Backward compatible with existing usage
- ✅ All feedback messages implemented as specified

## Related Issues

Resolves #9

## Documentation

- [ ] Issue #8 updated with documentation TODO for this feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)