### PR TITLE
feat: add --fields flag to list subcommand

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -56,6 +56,10 @@ pub enum Commands {
         /// Use "all" to display all available fields
         #[arg(long, value_delimiter = ',')]
         fields: Option<Vec<String>>,
+
+        /// Maximum length for prompt field before truncation (0 = no truncation)
+        #[arg(long, default_value_t = 30)]
+        prompt_max_length: usize,
     },
     /// Show details of a specific preset
     Show {

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -6,8 +6,6 @@ use comfy_table::Table;
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 
-const PROMPT_MAX_LENGTH: usize = 30;
-
 fn validate_fields(fields: &[String]) -> Result<Vec<String>> {
     const VALID_FIELDS: &[&str] = &[
         "name",
@@ -57,7 +55,12 @@ fn field_to_header(field: &str) -> &str {
     }
 }
 
-fn build_row(preset: &Preset, path: &Path, fields: &[String]) -> Vec<String> {
+fn build_row(
+    preset: &Preset,
+    path: &Path,
+    fields: &[String],
+    prompt_max_length: usize,
+) -> Vec<String> {
     fields
         .iter()
         .map(|field| match field.as_str() {
@@ -79,8 +82,8 @@ fn build_row(preset: &Preset, path: &Path, fields: &[String]) -> Vec<String> {
                 .prompt
                 .as_deref()
                 .map(|p| {
-                    if p.chars().count() > PROMPT_MAX_LENGTH {
-                        let truncated: String = p.chars().take(PROMPT_MAX_LENGTH).collect();
+                    if prompt_max_length > 0 && p.chars().count() > prompt_max_length {
+                        let truncated: String = p.chars().take(prompt_max_length).collect();
                         format!("{}...", truncated)
                     } else {
                         p.to_string()
@@ -97,6 +100,7 @@ pub fn list(
     preset: Option<&str>,
     verbose: bool,
     fields: Option<&[String]>,
+    prompt_max_length: usize,
 ) -> Result<()> {
     let preset_dirs = loader::get_preset_dirs_scoped(scope)?;
 
@@ -177,7 +181,7 @@ pub fn list(
 
         // Build rows dynamically based on display_fields
         for (path, preset_obj) in &dir_presets {
-            let row = build_row(preset_obj, path, &display_fields);
+            let row = build_row(preset_obj, path, &display_fields, prompt_max_length);
             table.add_row(row);
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,12 +29,14 @@ fn run(cli: Cli) -> Result<ExitCode> {
             name,
             verbose,
             fields,
+            prompt_max_length,
         } => {
             claudio::commands::list::list(
                 scope.scope,
                 name.as_deref(),
                 *verbose,
                 fields.as_deref(),
+                *prompt_max_length,
             )?;
             ExitCode::SUCCESS
         }


### PR DESCRIPTION
This pull request adds support for customizable output fields in the `list` command, allowing users to specify which preset fields to display. It introduces a new `fields` argument, enables validation and dynamic table generation based on selected fields, and improves the flexibility of the CLI output.

**Customizable fields in `list` command:**

* Added a new `fields` option (comma-separated or multiple flags) to the `list` command in `src/cli.rs`, letting users specify which preset fields to display, including a special "all" option.
* Updated the `list` function signature in `src/commands/list.rs` to accept an optional `fields` parameter and handle it accordingly.
* Implemented `validate_fields` to ensure only valid field names are accepted, and `build_row` to dynamically construct table rows based on the selected fields.
* Modified table header and row construction logic in `src/commands/list.rs` to use the selected fields, overriding verbose mode if custom fields are provided.
* Updated the main command dispatch in `src/main.rs` to pass the new `fields` parameter to the `list` function.