### PR TITLE
feat: group preset CRUD commands under preset subcommand

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -51,6 +51,20 @@ pub enum Commands {
         #[arg(last = true, allow_hyphen_values = true)]
         claude_args: Vec<String>,
     },
+    /// Initialize a project-local preset directory at `<project-root>/.claudio/presets`
+    Init {
+        #[command(flatten)]
+        scope: ScopeArgs,
+    },
+    /// Manage presets (list, show, edit, env)
+    Preset {
+        #[command(subcommand)]
+        command: PresetCommands,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum PresetCommands {
     /// List all available presets (optionally filter by name)
     List {
         /// Optional preset name to filter by (prints matching preset file paths)
@@ -94,11 +108,6 @@ pub enum Commands {
         /// Preset name to edit
         preset: String,
 
-        #[command(flatten)]
-        scope: ScopeArgs,
-    },
-    /// Initialize a project-local preset directory at `<project-root>/.claudio/presets`
-    Init {
         #[command(flatten)]
         scope: ScopeArgs,
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,7 @@ use anyhow::Result;
 use clap::Parser;
 use std::process::ExitCode;
 
-use claudio::cli::Commands;
-use claudio::cli::{Cli, Scope};
+use claudio::cli::{Cli, Commands, PresetCommands, Scope};
 use claudio::color::{ColorConfig, HighlightColor};
 use claudio::settings::loader as settings_loader;
 
@@ -12,12 +11,13 @@ fn main() -> ExitCode {
 
     // Determine the scope for settings lookup (default to Auto for global settings)
     let settings_scope = match &cli.command {
-        Commands::Run { scope, .. }
-        | Commands::List { scope, .. }
-        | Commands::Show { scope, .. }
-        | Commands::Edit { scope, .. }
-        | Commands::Init { scope }
-        | Commands::Env { scope, .. } => scope.scope,
+        Commands::Run { scope, .. } | Commands::Init { scope } => scope.scope,
+        Commands::Preset { command } => match command {
+            PresetCommands::List { scope, .. }
+            | PresetCommands::Show { scope, .. }
+            | PresetCommands::Edit { scope, .. }
+            | PresetCommands::Env { scope, .. } => scope.scope,
+        },
     };
 
     // Initialize color config with settings as defaults, CLI flags override
@@ -92,49 +92,51 @@ fn run(cli: Cli, color_config: ColorConfig) -> Result<ExitCode> {
                 &color_config,
             )?
         }
-        Commands::List {
-            scope,
-            name,
-            verbose,
-            fields,
-            prompt_max_length,
-        } => {
-            claudio::commands::list::list(
-                scope.scope,
-                name.as_deref(),
-                *verbose,
-                fields.as_deref(),
-                *prompt_max_length,
-                &color_config,
-            )?;
-            ExitCode::SUCCESS
-        }
-        Commands::Show {
-            preset,
-            scope,
-            resolved,
-            json,
-        } => {
-            claudio::commands::show::show(preset, scope.scope, *resolved, *json)?;
-            ExitCode::SUCCESS
-        }
-        Commands::Edit { preset, scope } => {
-            claudio::commands::edit::edit(preset, scope.scope)?;
-            ExitCode::SUCCESS
-        }
         Commands::Init { scope } => {
             claudio::commands::init::init(scope.scope)?;
             ExitCode::SUCCESS
         }
-        Commands::Env {
-            preset,
-            scope,
-            export,
-            resolved,
-        } => {
-            claudio::commands::env::env(preset, scope.scope, *export, *resolved)?;
-            ExitCode::SUCCESS
-        }
+        Commands::Preset { command } => match command {
+            PresetCommands::List {
+                scope,
+                name,
+                verbose,
+                fields,
+                prompt_max_length,
+            } => {
+                claudio::commands::list::list(
+                    scope.scope,
+                    name.as_deref(),
+                    *verbose,
+                    fields.as_deref(),
+                    *prompt_max_length,
+                    &color_config,
+                )?;
+                ExitCode::SUCCESS
+            }
+            PresetCommands::Show {
+                preset,
+                scope,
+                resolved,
+                json,
+            } => {
+                claudio::commands::show::show(preset, scope.scope, *resolved, *json)?;
+                ExitCode::SUCCESS
+            }
+            PresetCommands::Edit { preset, scope } => {
+                claudio::commands::edit::edit(preset, scope.scope)?;
+                ExitCode::SUCCESS
+            }
+            PresetCommands::Env {
+                preset,
+                scope,
+                export,
+                resolved,
+            } => {
+                claudio::commands::env::env(preset, scope.scope, *export, *resolved)?;
+                ExitCode::SUCCESS
+            }
+        },
     };
 
     Ok(exit_code)


### PR DESCRIPTION
Reorganize the CLI structure to improve discoverability and UX by grouping
all preset-related CRUD operations under a dedicated `preset` subcommand.

New command structure:
  - claudio preset list   (was: claudio list)
  - claudio preset show   (was: claudio show)
  - claudio preset edit   (was: claudio edit)
  - claudio preset env    (was: claudio env)

Top-level commands remain unchanged:
  - claudio run
  - claudio init

This change is a mechanical refactoring with no impact on command logic.
All functionality continues to work with the new command paths.

🤖 Generated with Claude Code

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
