### PR TITLE
fix: remove trim() calls causing column misalignment in list command

### DIFF
--- a/crates/claudio/src/commands/list.rs
+++ b/crates/claudio/src/commands/list.rs
@@ -223,9 +223,9 @@ pub fn list(
             table.add_row(row);
         }
 
-        // Print table with trimmed lines (removes leading whitespace from NOTHING preset)
+        // Print table lines
         for line in table.lines() {
-            println!("{}", line.trim());
+            println!("{}", line);
         }
         println!();
     }
@@ -293,7 +293,7 @@ pub fn list(
         }
 
         for line in table.lines() {
-            println!("{}", line.trim());
+            println!("{}", line);
         }
         println!();
     }


### PR DESCRIPTION
### **User description**
## Summary

Fixes #72

The `claudio list` command was displaying tables with headers and columns offset by one whitespace character.

## Root Cause

The issue was caused by calling `.trim()` on each line of the `comfy_table` output. The `comfy_table` library with the `NOTHING` preset includes intentional padding for proper column alignment, and trimming each line independently was removing this padding.

## Changes

- Removed `.trim()` call at line 228 when printing file-based presets table
- Removed `.trim()` call at line 296 when printing inline presets table
- Updated comment to reflect the fix

## Test Plan

- Run `claudio list` and verify headers align with columns
- Test with various preset configurations
- Verify alignment works with different terminal widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Remove `.trim()` calls causing column misalignment in list output

- Preserve intentional padding from `comfy_table` NOTHING preset

- Fix headers and data columns offset by one space


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["comfy_table output<br/>with padding"] -->|"remove trim()"| B["Properly aligned<br/>headers and columns"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>list.rs</strong><dd><code>Remove trim() calls from table printing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/claudio/src/commands/list.rs

<ul><li>Removed <code>.trim()</code> call on line 228 for file-based presets table output<br> <li> Removed <code>.trim()</code> call on line 296 for inline presets table output<br> <li> Updated comment from 'Print table with trimmed lines' to 'Print table <br>lines'</ul>


</details>


  </td>
  <td><a href="https://github.com/binado/claudio/pull/73/files#diff-1c974566b7cb418a1e6602d1ebf255c77c6bbc76db87eeb1dc1c0072849a0590">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

