### PR TITLE
fix(claudio init): create settings.json in project scope with Scope::Auto

### DIFF
--- a/crates/claudio-core/src/settings/loader.rs
+++ b/crates/claudio-core/src/settings/loader.rs
@@ -18,10 +18,10 @@ pub fn get_settings_path(scope: Scope) -> Result<PathBuf> {
         Scope::Auto => {
             // For Auto scope, we prefer project if one can be detected (matching preset behavior).
             // The caller is responsible for checking if the file exists.
-            if let Some(project_path) = get_project_settings_path() {
-                return Ok(project_path);
+            match get_project_settings_path() {
+                Some(project_path) => Ok(project_path),
+                None => get_user_settings_path(),
             }
-            Ok(get_user_settings_path()?)
         }
     }
 }

--- a/crates/claudio-core/src/settings/loader.rs
+++ b/crates/claudio-core/src/settings/loader.rs
@@ -8,17 +8,17 @@ use std::path::PathBuf;
 ///
 /// - Project: `<project-root>/.claudio/settings.json`
 /// - User: `~/.claudio/settings.json`
-/// - Auto: Prefer project if it exists, otherwise user
+/// - Auto: Prefer project if detected in a git repo, otherwise user
+///   (Note: The returned path may not exist; caller is responsible for checking)
 pub fn get_settings_path(scope: Scope) -> Result<PathBuf> {
     match scope {
         Scope::Project => get_project_settings_path()
             .ok_or_else(|| anyhow::anyhow!("Failed to determine project root")),
         Scope::User => Ok(get_user_settings_path()?),
         Scope::Auto => {
-            // For Auto scope, we prefer project if it exists
-            if let Some(project_path) = get_project_settings_path()
-                && project_path.exists()
-            {
+            // For Auto scope, we prefer project if one can be detected (matching preset behavior).
+            // The caller is responsible for checking if the file exists.
+            if let Some(project_path) = get_project_settings_path() {
                 return Ok(project_path);
             }
             Ok(get_user_settings_path()?)


### PR DESCRIPTION
### **User description**
The get_settings_path function was checking if the project settings file exists
before returning the project path. This caused a bug where 'claudio init' without
an explicit --scope flag would not create the settings.json file in the project
directory, even when inside a git repository.

The issue was that:
1. During init, we're trying to CREATE the file
2. The file doesn't exist yet (chicken-and-egg problem)
3. So get_settings_path would fall back to user scope
4. If user settings already exist, init wouldn't create anything

The fix aligns the Scope::Auto logic with get_preset_write_dir_scoped, which
correctly returns the project path based on git repo detection, not file existence.
Callers are now responsible for checking if files exist when needed.

This fixes issue #83.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>


___

### **PR Type**
Bug fix


___

### **Description**
- Fix Scope::Auto logic to detect project scope by git repo presence, not file existence

- Remove file existence check that prevented settings.json creation in project scope

- Align behavior with get_preset_write_dir_scoped for consistent scope detection

- Update documentation to clarify caller responsibility for file existence checks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Scope::Auto Detection"] --> B["Check git repo presence"]
  B --> C["Return project path"]
  C --> D["Caller creates file if needed"]
  B --> E["Fall back to user path"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>loader.rs</strong><dd><code>Remove file existence check from Scope::Auto logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/claudio-core/src/settings/loader.rs

<ul><li>Removed file existence check from Scope::Auto logic that was <br>preventing project scope selection<br> <li> Changed condition to only check if project path can be detected via <br>git repo<br> <li> Updated documentation comments to clarify Auto scope behavior and <br>caller responsibilities<br> <li> Aligned implementation with get_preset_write_dir_scoped pattern for <br>consistent behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/binado/claudio/pull/84/files#diff-d8cd54ab94fbff59fd899d14562d1b1487b12121e140233c626659847fc5525f">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

