### PR TITLE
fix(preset-list): honor --fields for --json output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,13 +91,14 @@ Behavior:
 List available presets.
 
 ```bash
-claudio preset list [NAME] [--scope SCOPE] [--verbose] [--fields FIELDS]
+claudio preset list [NAME] [--scope SCOPE] [--fields FIELDS] [--max-width N] [--json]
 ```
 
 Options:
 - `NAME` - Filter by preset name
-- `--verbose` - Show detailed information
-- `--fields` - Customize displayed fields (name, description, filepath, env, args, extends, prompt)
+- `--fields` - Customize displayed fields (name, description, filepath, env, args, extends, prompt); also filters `--json` item fields
+- `--max-width` - Limit table width (ignored with `--json`)
+- `--json` - Output as JSON for scripting and automation
 
 ### `claudio preset show <preset>`
 

--- a/README.md
+++ b/README.md
@@ -124,16 +124,20 @@ claudio preset list --json | jq '.items[] | select(.is_default == true)'
 
 **Example output:**
 ```
-Available presets:
+=== User Presets ===
+Location: /Users/you/.claudio/presets
 
-User (~/.claudio/presets/):
-  minimax-fast           Minimax with MCPs disabled for speed
-  openrouter             OpenRouter API for multiple models
+Name          Description                           Filepath
+* minimax-fast Minimax with MCPs disabled for speed  /Users/you/.claudio/presets/minimax-fast.json
+openrouter     OpenRouter API for multiple models    /Users/you/.claudio/presets/openrouter.json
 
-Project (./.claudio/presets/):
-  code-review            Code review with custom settings
+=== Project Presets ===
+Location: /path/to/repo/.claudio/presets
 
-3 presets found
+Name        Description                      Filepath
+code-review Code review with custom settings /path/to/repo/.claudio/presets/code-review.json
+
+* indicates default preset
 ```
 </details>
 

--- a/README.md
+++ b/README.md
@@ -105,15 +105,21 @@ claudio preset list
 claudio preset list --scope user
 claudio preset list --scope project
 
-# Verbose output with full details
-claudio preset list --verbose
+# Show all fields
+claudio preset list --fields all
 
-# Search for a specific preset
+# Filter by preset name (exact match)
 claudio preset list minimax-fast
 
 # Custom fields display
 claudio preset list --fields name,description,filepath
-claudio preset list --fields all
+
+# Limit table width
+claudio preset list --max-width 100
+
+# Output as JSON for scripting
+claudio preset list --json
+claudio preset list --json | jq '.items[] | select(.is_default == true)'
 ```
 
 **Example output:**

--- a/crates/claudio-core/src/paths.rs
+++ b/crates/claudio-core/src/paths.rs
@@ -71,10 +71,16 @@ pub fn find_project_root(start: Option<&Path>) -> Option<PathBuf> {
         None => std::env::current_dir().ok()?,
     };
 
+    // Get user's home directory to exclude it from project root detection
+    // This prevents ~/.claudio from being incorrectly identified as a project root
+    let user_home = BaseDirs::new()?.home_dir().to_path_buf();
+
     let mut dir: &Path = &start;
 
     loop {
-        if dir.join(".claudio").is_dir() || dir.join(".git").is_dir() {
+        // Skip if this is the user's home directory - ~/.claudio is the user-level config,
+        // not a project root
+        if dir != user_home && (dir.join(".claudio").is_dir() || dir.join(".git").is_dir()) {
             return Some(dir.to_path_buf());
         }
 
@@ -175,6 +181,53 @@ mod tests {
 
         unsafe {
             env::remove_var(CLAUDIO_HOME_DIR_ENV_VAR);
+        }
+    }
+
+    #[test]
+    fn test_find_project_root_excludes_user_home() {
+        // Create a temporary directory structure:
+        // temp/
+        //   .claudio/  (simulating user home)
+        //   project/
+        //     .git/
+        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_path = temp_dir.path();
+
+        // Create .claudio in the temp root (simulating user home with ~/.claudio)
+        std::fs::create_dir(temp_path.join(".claudio")).unwrap();
+
+        // Create a project subdirectory with .git
+        let project_dir = temp_path.join("project");
+        std::fs::create_dir(&project_dir).unwrap();
+        std::fs::create_dir(project_dir.join(".git")).unwrap();
+
+        // When searching from the project directory, it should find the project root,
+        // not traverse up to the temp root (which has .claudio)
+        let result = find_project_root(Some(&project_dir));
+
+        assert_eq!(result, Some(project_dir.clone()));
+    }
+
+    #[test]
+    fn test_find_project_root_at_actual_user_home() {
+        // This test verifies that when .claudio exists in the actual user's home directory,
+        // it is not considered a project root
+        let home = BaseDirs::new().unwrap().home_dir().to_path_buf();
+
+        // If ~/.claudio exists (which it likely does), searching from a subdirectory
+        // should not return the home directory as a project root
+        if home.join(".claudio").exists() {
+            let result = find_project_root(Some(&home));
+
+            // Should not find home directory itself as a project root even if it has .claudio
+            // (Note: this might return None, or it might find a parent .git if the home is inside a git repo)
+            if let Some(root) = result {
+                assert_ne!(
+                    root, home,
+                    "User home directory should not be considered a project root even with ~/.claudio"
+                );
+            }
         }
     }
 }

--- a/crates/claudio/src/cli.rs
+++ b/crates/claudio/src/cli.rs
@@ -5,7 +5,9 @@ use claudio_core::scope::Scope as CoreScope;
 
 #[derive(Debug, Clone, Copy, PartialEq, ValueEnum)]
 pub enum Scope {
-    /// Use the default resolution behavior (project shadows user for reads).
+    /// Use the default resolution behavior.
+    /// For 'run': Project shadows user (first match wins).
+    /// For 'list': Shows presets from both scopes (unless project settings set ignore_user_presets).
     Auto,
     /// Only use project-local presets from `./.claudio/presets`.
     Project,
@@ -130,15 +132,11 @@ pub enum Commands {
 pub enum PresetCommands {
     /// List all available presets (optionally filter by name)
     List {
-        /// Optional preset name to filter by (prints matching preset file paths)
+        /// Optional preset name to filter by (exact match)
         name: Option<String>,
 
         #[command(flatten)]
         scope: ScopeArgs,
-
-        /// Show verbose output
-        #[arg(short, long)]
-        verbose: bool,
 
         /// Custom fields to display (comma-separated or multiple flags)
         /// Available: name, description, filepath, env, args, extends, prompt
@@ -146,9 +144,13 @@ pub enum PresetCommands {
         #[arg(long, value_delimiter = ',')]
         fields: Option<Vec<String>>,
 
-        /// Maximum length for prompt field before truncation (0 = no truncation)
-        #[arg(long, default_value_t = 30)]
-        prompt_max_length: usize,
+        /// Maximum table width (0 = no explicit limit)
+        #[arg(long, default_value_t = 0)]
+        max_width: usize,
+
+        /// Output as JSON for scripting and automation
+        #[arg(long)]
+        json: bool,
     },
     /// Show details of a specific preset
     Show {

--- a/crates/claudio/src/cli.rs
+++ b/crates/claudio/src/cli.rs
@@ -138,13 +138,13 @@ pub enum PresetCommands {
         #[command(flatten)]
         scope: ScopeArgs,
 
-        /// Custom fields to display (comma-separated or multiple flags)
+        /// Custom fields to display (table columns; also filters `--json` item fields)
         /// Available: name, description, filepath, env, args, extends, prompt
         /// Use "all" to display all available fields
         #[arg(long, value_delimiter = ',')]
         fields: Option<Vec<String>>,
 
-        /// Maximum table width (0 = no explicit limit)
+        /// Maximum table width (0 = no explicit limit; ignored with `--json`)
         #[arg(long, default_value_t = 0)]
         max_width: usize,
 

--- a/crates/claudio/src/commands/list.rs
+++ b/crates/claudio/src/commands/list.rs
@@ -348,32 +348,6 @@ pub fn list(
                 continue;
             }
 
-            // Find the corresponding directory for location display
-            let dir_path = if *scope_label == "project" {
-                preset_dirs.first()
-            } else {
-                preset_dirs.get(if preset_dirs.len() > 1 { 1 } else { 0 })
-            };
-
-            // Enhanced section header
-            let header = format!(
-                "=== {} Presets ===",
-                if *scope_label == "project" {
-                    "Project"
-                } else {
-                    "User"
-                }
-            );
-            if color_config.enabled {
-                println!("\n{}", color_config.highlight(&header));
-            } else {
-                println!("\n{}", header);
-            }
-            if let Some(dir) = dir_path {
-                println!("Location: {}", dir.display());
-            }
-            println!();
-
             let mut table = Table::new();
             table.load_preset(comfy_table::presets::NOTHING);
 

--- a/crates/claudio/src/commands/list.rs
+++ b/crates/claudio/src/commands/list.rs
@@ -171,7 +171,7 @@ pub fn list(
     let effective_scope = effective_read_scope(scope);
     let preset_dirs = dirs::get_preset_dirs_scoped(effective_scope)?;
 
-    if !json && max_width > u16::MAX as usize {
+    if max_width > u16::MAX as usize {
         anyhow::bail!("--max-width must be <= {}", u16::MAX);
     }
 

--- a/crates/claudio/src/commands/list.rs
+++ b/crates/claudio/src/commands/list.rs
@@ -5,10 +5,46 @@ use claudio_core::preset::{dirs, io};
 use claudio_core::scope::Scope;
 use claudio_core::settings::loader as settings_loader;
 use comfy_table::{Attribute, Cell, CellAlignment, ContentArrangement, Table};
+use serde::Serialize;
 use std::borrow::Cow;
-use std::path::PathBuf;
 
 use crate::commands::effective_read_scope;
+
+// JSON output structures
+#[derive(Serialize)]
+struct PresetListItem {
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    filepath: Option<String>,
+    scope: String,  // "project" | "user"
+    source: String, // "file" | "inline"
+    is_default: bool,
+    // Optional extra fields
+    #[serde(skip_serializing_if = "Option::is_none")]
+    env_keys: Option<Vec<String>>, // keys only; do not emit values
+    #[serde(skip_serializing_if = "Option::is_none")]
+    args: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    extends: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    prompt: Option<String>,
+}
+
+#[derive(Serialize)]
+struct InvalidPresetFile {
+    path: String,
+    error: String,
+}
+
+#[derive(Serialize)]
+struct PresetListOutput {
+    items: Vec<PresetListItem>,
+    default_preset: Option<String>,
+    scopes: Vec<String>,
+    invalid_files: Vec<InvalidPresetFile>,
+}
 
 fn validate_fields(fields: &[String]) -> Result<Vec<String>> {
     const VALID_FIELDS: &[&str] = &[
@@ -59,22 +95,9 @@ fn field_to_header(field: &str) -> &str {
     }
 }
 
-fn get_display_fields<'a>(
-    validated_fields: &'a Option<Vec<String>>,
-    verbose: bool,
-) -> Cow<'a, [String]> {
+fn get_display_fields<'a>(validated_fields: &'a Option<Vec<String>>) -> Cow<'a, [String]> {
     if let Some(validated) = validated_fields {
         Cow::Borrowed(validated)
-    } else if verbose {
-        Cow::Owned(vec![
-            "name".to_string(),
-            "description".to_string(),
-            "filepath".to_string(),
-            "env".to_string(),
-            "args".to_string(),
-            "extends".to_string(),
-            "prompt".to_string(),
-        ])
     } else {
         Cow::Owned(vec![
             "name".to_string(),
@@ -88,41 +111,44 @@ fn build_row(
     preset: &Preset,
     filepath_display: &str,
     fields: &[String],
-    prompt_max_length: usize,
+    default_preset: Option<&str>,
+    color_config: &ColorConfig,
+    env_keys: Option<&[String]>,
 ) -> Vec<Cell> {
     fields
         .iter()
-        .map(|field| {
-            let value = match field.as_str() {
-                "name" => preset.name.clone(),
-                "description" => preset.description.as_deref().unwrap_or("").to_string(),
-                "filepath" => filepath_display.to_string(),
-                "env" => preset
-                    .env
-                    .as_ref()
-                    .map(|e| e.keys().map(|k| k.as_str()).collect::<Vec<_>>().join(", "))
-                    .unwrap_or_default(),
-                "args" => preset
-                    .args
-                    .as_ref()
-                    .map(|a| a.join(", "))
-                    .unwrap_or_default(),
-                "extends" => preset.extends.as_deref().unwrap_or("none").to_string(),
-                "prompt" => preset
-                    .prompt
-                    .as_deref()
-                    .map(|p| {
-                        if prompt_max_length > 0 && p.chars().count() > prompt_max_length {
-                            let truncated: String = p.chars().take(prompt_max_length).collect();
-                            format!("{}...", truncated)
-                        } else {
-                            p.to_string()
-                        }
-                    })
-                    .unwrap_or_default(),
-                _ => String::new(),
-            };
-            Cell::new(value).set_alignment(CellAlignment::Left)
+        .map(|field| match field.as_str() {
+            "name" => {
+                let name = &preset.name;
+                let display_name = if Some(name.as_str()) == default_preset {
+                    format!("* {}", name)
+                } else {
+                    name.clone()
+                };
+                let mut cell = Cell::new(display_name).set_alignment(CellAlignment::Left);
+                if Some(name.as_str()) == default_preset && color_config.enabled {
+                    cell = cell
+                        .fg(color_config.highlight_color.to_comfy_color())
+                        .add_attribute(Attribute::Bold);
+                }
+                cell
+            }
+            field_name => {
+                let value = match field_name {
+                    "description" => preset.description.as_deref().unwrap_or("").to_string(),
+                    "filepath" => filepath_display.to_string(),
+                    "env" => env_keys.map(|keys| keys.join(", ")).unwrap_or_default(),
+                    "args" => preset
+                        .args
+                        .as_ref()
+                        .map(|a| a.join(", "))
+                        .unwrap_or_default(),
+                    "extends" => preset.extends.as_deref().unwrap_or("none").to_string(),
+                    "prompt" => preset.prompt.as_deref().unwrap_or("").to_string(),
+                    _ => String::new(),
+                };
+                Cell::new(value).set_alignment(CellAlignment::Left)
+            }
         })
         .collect()
 }
@@ -130,25 +156,46 @@ fn build_row(
 pub fn list(
     scope: Scope,
     preset: Option<&str>,
-    verbose: bool,
     fields: Option<&[String]>,
-    prompt_max_length: usize,
+    max_width: usize,
+    json: bool,
     color_config: &ColorConfig,
 ) -> Result<()> {
     let effective_scope = effective_read_scope(scope);
     let preset_dirs = dirs::get_preset_dirs_scoped(effective_scope)?;
 
-    // Validate fields once before processing any directories
+    // Load default preset to highlight it
+    let default_preset = settings_loader::resolve_default_preset(effective_scope)
+        .ok()
+        .flatten();
+
+    // Validate fields once before processing
     let validated_fields = if let Some(custom_fields) = fields {
         Some(validate_fields(custom_fields)?)
     } else {
         None
     };
 
-    let mut skipped_count = 0;
+    // Unified data collection
+    let mut all_items: Vec<PresetListItem> = Vec::new();
+    let mut invalid_files: Vec<InvalidPresetFile> = Vec::new();
+    let mut scopes_used: Vec<String> = Vec::new();
 
-    for dir in &preset_dirs {
-        let mut dir_presets = Vec::<(PathBuf, Preset)>::new();
+    // Collect file-based presets with proper scope labeling
+    for (dir_index, dir) in preset_dirs.iter().enumerate() {
+        // Determine scope label based on known order (not CWD-based)
+        let scope_label = match effective_scope {
+            Scope::Project => "project",
+            Scope::User => "user",
+            Scope::Auto => {
+                // For Auto scope, first dir is project (if it exists), second is user
+                if dir_index == 0 { "project" } else { "user" }
+            }
+        };
+
+        if !scopes_used.contains(&scope_label.to_string()) {
+            scopes_used.push(scope_label.to_string());
+        }
 
         if let Ok(entries) = std::fs::read_dir(dir) {
             for entry in entries.flatten() {
@@ -161,78 +208,37 @@ pub fn list(
                 match io::load_preset(&path) {
                     Ok(preset_obj) => {
                         if preset.is_none() || preset_obj.name == preset.unwrap() {
-                            dir_presets.push((path, preset_obj));
+                            let is_default = Some(&preset_obj.name) == default_preset.as_ref();
+
+                            all_items.push(PresetListItem {
+                                name: preset_obj.name.clone(),
+                                description: preset_obj.description.clone(),
+                                filepath: Some(path.display().to_string()),
+                                scope: scope_label.to_string(),
+                                source: "file".to_string(),
+                                is_default,
+                                env_keys: preset_obj
+                                    .env
+                                    .as_ref()
+                                    .map(|e| e.keys().map(|k| k.to_string()).collect()),
+                                args: preset_obj.args.clone(),
+                                extends: preset_obj.extends.clone(),
+                                prompt: preset_obj.prompt.clone(),
+                            });
                         }
                     }
                     Err(err) => {
-                        skipped_count += 1;
-                        if verbose {
-                            eprintln!("Warning: invalid preset file: {} ({})", path.display(), err);
-                        }
+                        invalid_files.push(InvalidPresetFile {
+                            path: path.display().to_string(),
+                            error: err.to_string(),
+                        });
                     }
                 }
             }
         }
-
-        if dir_presets.is_empty() {
-            continue;
-        }
-
-        let cwd = std::env::current_dir().ok();
-        let source = if cwd.as_ref().is_some_and(|c| dir.starts_with(c)) {
-            "Project"
-        } else {
-            "User"
-        };
-
-        println!("{} ({}):", source, dir.display());
-
-        let mut table = Table::new();
-        table
-            .load_preset(comfy_table::presets::NOTHING)
-            .set_content_arrangement(ContentArrangement::Disabled);
-
-        // Determine which fields to display
-        let display_fields = get_display_fields(&validated_fields, verbose);
-
-        // Set headers based on display_fields with explicit left alignment
-        // Use comfy-table's native styling to ensure proper width calculation
-        let headers: Vec<Cell> = display_fields
-            .iter()
-            .map(|f| {
-                let cell = Cell::new(field_to_header(f)).set_alignment(CellAlignment::Left);
-                if color_config.enabled {
-                    cell.fg(color_config.highlight_color.to_comfy_color())
-                        .add_attribute(Attribute::Bold)
-                } else {
-                    cell
-                }
-            })
-            .collect();
-        table.set_header(headers);
-
-        // Build rows dynamically based on display_fields
-        for (path, preset_obj) in &dir_presets {
-            let filepath_display = path.display().to_string();
-            let row = build_row(
-                preset_obj,
-                &filepath_display,
-                &display_fields,
-                prompt_max_length,
-            );
-            table.add_row(row);
-        }
-
-        // Print table lines
-        for line in table.lines() {
-            println!("{}", line);
-        }
-        println!();
     }
 
-    // Inline presets (from settings)
-    let mut inline_project: Vec<Preset> = Vec::new();
-    let mut inline_user: Vec<Preset> = Vec::new();
+    // Collect inline presets
     for (origin, preset_obj) in settings_loader::load_inline_presets_scoped(effective_scope)? {
         if let Some(filter_name) = preset
             && preset_obj.name != filter_name
@@ -240,71 +246,257 @@ pub fn list(
             continue;
         }
 
-        match origin {
-            Scope::Project => inline_project.push(preset_obj),
-            Scope::User => inline_user.push(preset_obj),
+        let scope_label = match origin {
+            Scope::Project => "project",
+            Scope::User => "user",
             Scope::Auto => unreachable!(
                 "Scope::Auto should not be returned as an origin by load_inline_presets_scoped"
             ),
-        }
-    }
-
-    let inline_sections: Vec<(&str, Vec<Preset>)> = match effective_scope {
-        Scope::Project => vec![("Inline", inline_project)],
-        Scope::User => vec![("Inline", inline_user)],
-        Scope::Auto => vec![
-            ("Inline (project)", inline_project),
-            ("Inline (user)", inline_user),
-        ],
-    };
-
-    for (label, presets) in inline_sections {
-        if presets.is_empty() {
-            continue;
-        }
-
-        println!("{}:", label);
-
-        let mut table = Table::new();
-        table
-            .load_preset(comfy_table::presets::NOTHING)
-            .set_content_arrangement(ContentArrangement::Disabled);
-
-        // Determine which fields to display
-        let display_fields = get_display_fields(&validated_fields, verbose);
-
-        let headers: Vec<Cell> = display_fields
-            .iter()
-            .map(|f| {
-                let cell = Cell::new(field_to_header(f)).set_alignment(CellAlignment::Left);
-                if color_config.enabled {
-                    cell.fg(color_config.highlight_color.to_comfy_color())
-                        .add_attribute(Attribute::Bold)
-                } else {
-                    cell
-                }
-            })
-            .collect();
-        table.set_header(headers);
-
-        for preset_obj in &presets {
-            let row = build_row(preset_obj, "(inline)", &display_fields, prompt_max_length);
-            table.add_row(row);
-        }
-
-        for line in table.lines() {
-            println!("{}", line);
-        }
-        println!();
-    }
-
-    if skipped_count > 0 && !verbose {
-        let msg = if skipped_count == 1 {
-            "1 invalid preset file skipped".to_string()
-        } else {
-            format!("{} invalid preset files skipped", skipped_count)
         };
-        eprintln!("({}, use --verbose to see details)", msg);
+
+        if !scopes_used.contains(&scope_label.to_string()) {
+            scopes_used.push(scope_label.to_string());
+        }
+
+        let is_default = Some(&preset_obj.name) == default_preset.as_ref();
+
+        all_items.push(PresetListItem {
+            name: preset_obj.name.clone(),
+            description: preset_obj.description.clone(),
+            filepath: None,
+            scope: scope_label.to_string(),
+            source: "inline".to_string(),
+            is_default,
+            env_keys: preset_obj
+                .env
+                .as_ref()
+                .map(|e| e.keys().map(|k| k.to_string()).collect()),
+            args: preset_obj.args.clone(),
+            extends: preset_obj.extends.clone(),
+            prompt: preset_obj.prompt.clone(),
+        });
+    }
+
+    // Output based on format
+    if json {
+        let output = PresetListOutput {
+            items: all_items,
+            default_preset,
+            scopes: scopes_used,
+            invalid_files,
+        };
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        // Table output
+        let display_fields = get_display_fields(&validated_fields);
+
+        // Group items by scope and source for display
+        let mut default_was_rendered = false;
+
+        // Display file-based presets grouped by scope
+        for scope_label in &["project", "user"] {
+            let scope_items: Vec<&PresetListItem> = all_items
+                .iter()
+                .filter(|item| item.source == "file" && item.scope == *scope_label)
+                .collect();
+
+            if scope_items.is_empty() {
+                continue;
+            }
+
+            // Find the corresponding directory for location display
+            let dir_path = if *scope_label == "project" {
+                preset_dirs.first()
+            } else {
+                preset_dirs.get(if preset_dirs.len() > 1 { 1 } else { 0 })
+            };
+
+            // Enhanced section header
+            let header = format!(
+                "=== {} Presets ===",
+                if *scope_label == "project" {
+                    "Project"
+                } else {
+                    "User"
+                }
+            );
+            if color_config.enabled {
+                println!("\n{}", color_config.highlight(&header));
+            } else {
+                println!("\n{}", header);
+            }
+            if let Some(dir) = dir_path {
+                println!("Location: {}", dir.display());
+            }
+            println!();
+
+            let mut table = Table::new();
+            table.load_preset(comfy_table::presets::NOTHING);
+
+            // Apply max width if specified
+            if max_width > 0 {
+                table
+                    .set_content_arrangement(ContentArrangement::DynamicFullWidth)
+                    .set_width(max_width as u16);
+            } else {
+                table.set_content_arrangement(ContentArrangement::Disabled);
+            }
+
+            // Set headers
+            let headers: Vec<Cell> = display_fields
+                .iter()
+                .map(|f| {
+                    let cell = Cell::new(field_to_header(f)).set_alignment(CellAlignment::Left);
+                    if color_config.enabled {
+                        cell.fg(color_config.highlight_color.to_comfy_color())
+                            .add_attribute(Attribute::Bold)
+                    } else {
+                        cell
+                    }
+                })
+                .collect();
+            table.set_header(headers);
+
+            // Build rows
+            for item in scope_items {
+                if item.is_default {
+                    default_was_rendered = true;
+                }
+
+                // Convert PresetListItem back to Preset for build_row
+                let preset_obj = Preset {
+                    name: item.name.clone(),
+                    description: item.description.clone(),
+                    env: None, // Will use env_keys from item
+                    args: item.args.clone(),
+                    extends: item.extends.clone(),
+                    prompt: item.prompt.clone(),
+                    settings: None,
+                };
+
+                let filepath_display = item.filepath.as_deref().unwrap_or("");
+                let env_keys_slice = item.env_keys.as_deref();
+                let row = build_row(
+                    &preset_obj,
+                    filepath_display,
+                    &display_fields,
+                    default_preset.as_deref(),
+                    color_config,
+                    env_keys_slice,
+                );
+                table.add_row(row);
+            }
+
+            for line in table.lines() {
+                println!("{}", line);
+            }
+            println!();
+        }
+
+        // Display inline presets grouped by scope
+        for scope_label in &["project", "user"] {
+            let inline_items: Vec<&PresetListItem> = all_items
+                .iter()
+                .filter(|item| item.source == "inline" && item.scope == *scope_label)
+                .collect();
+
+            if inline_items.is_empty() {
+                continue;
+            }
+
+            let label = match effective_scope {
+                Scope::Project | Scope::User => "Inline",
+                Scope::Auto => {
+                    if *scope_label == "project" {
+                        "Inline (project)"
+                    } else {
+                        "Inline (user)"
+                    }
+                }
+            };
+
+            // Enhanced section header
+            let header = format!("=== {} ===", label);
+            if color_config.enabled {
+                println!("\n{}", color_config.highlight(&header));
+            } else {
+                println!("\n{}", header);
+            }
+            println!();
+
+            let mut table = Table::new();
+            table.load_preset(comfy_table::presets::NOTHING);
+
+            // Apply max width if specified
+            if max_width > 0 {
+                table
+                    .set_content_arrangement(ContentArrangement::DynamicFullWidth)
+                    .set_width(max_width as u16);
+            } else {
+                table.set_content_arrangement(ContentArrangement::Disabled);
+            }
+
+            let headers: Vec<Cell> = display_fields
+                .iter()
+                .map(|f| {
+                    let cell = Cell::new(field_to_header(f)).set_alignment(CellAlignment::Left);
+                    if color_config.enabled {
+                        cell.fg(color_config.highlight_color.to_comfy_color())
+                            .add_attribute(Attribute::Bold)
+                    } else {
+                        cell
+                    }
+                })
+                .collect();
+            table.set_header(headers);
+
+            for item in inline_items {
+                if item.is_default {
+                    default_was_rendered = true;
+                }
+
+                let preset_obj = Preset {
+                    name: item.name.clone(),
+                    description: item.description.clone(),
+                    env: None,
+                    args: item.args.clone(),
+                    extends: item.extends.clone(),
+                    prompt: item.prompt.clone(),
+                    settings: None,
+                };
+
+                let env_keys_slice = item.env_keys.as_deref();
+                let row = build_row(
+                    &preset_obj,
+                    "(inline)",
+                    &display_fields,
+                    default_preset.as_deref(),
+                    color_config,
+                    env_keys_slice,
+                );
+                table.add_row(row);
+            }
+
+            for line in table.lines() {
+                println!("{}", line);
+            }
+            println!();
+        }
+
+        // Print legend if default preset was shown
+        if default_was_rendered {
+            println!("* indicates default preset");
+        }
+
+        // Print invalid files summary
+        if !invalid_files.is_empty() {
+            let msg = if invalid_files.len() == 1 {
+                "1 invalid preset file skipped".to_string()
+            } else {
+                format!("{} invalid preset files skipped", invalid_files.len())
+            };
+            eprintln!("\n({}, run `claudio doctor` for details)", msg);
+        }
     }
 
     Ok(())

--- a/crates/claudio/src/commands/list.rs
+++ b/crates/claudio/src/commands/list.rs
@@ -171,6 +171,11 @@ pub fn list(
     let effective_scope = effective_read_scope(scope);
     let preset_dirs = dirs::get_preset_dirs_scoped(effective_scope)?;
 
+    // Pre-compute user directory path for accurate scope labeling in Auto mode
+    let user_dir_path = dirs::get_preset_dirs_scoped(Scope::User)
+        .ok()
+        .and_then(|mut dirs| dirs.pop());
+
     if max_width > u16::MAX as usize {
         anyhow::bail!("--max-width must be <= {}", u16::MAX);
     }
@@ -193,15 +198,13 @@ pub fn list(
     let mut scopes_used: Vec<String> = Vec::new();
 
     // Collect file-based presets with proper scope labeling
-    for (dir_index, dir) in preset_dirs.iter().enumerate() {
+    for dir in preset_dirs.iter() {
         // Determine scope label based on known order (not CWD-based)
         let scope_label = match effective_scope {
             Scope::Project => "project",
             Scope::User => "user",
             Scope::Auto => {
-                // For Auto scope, the user dir is always last; project (if present) comes before it.
-                let user_dir_index = preset_dirs.len().saturating_sub(1);
-                if dir_index == user_dir_index {
+                if user_dir_path.as_ref() == Some(dir) {
                     "user"
                 } else {
                     "project"

--- a/crates/claudio/src/commands/list.rs
+++ b/crates/claudio/src/commands/list.rs
@@ -46,6 +46,13 @@ struct PresetListOutput {
     invalid_files: Vec<InvalidPresetFile>,
 }
 
+fn should_include_json_field(validated_fields: &Option<Vec<String>>, field: &str) -> bool {
+    match validated_fields {
+        None => true,
+        Some(fields) => fields.iter().any(|f| f == field),
+    }
+}
+
 fn validate_fields(fields: &[String]) -> Result<Vec<String>> {
     const VALID_FIELDS: &[&str] = &[
         "name",
@@ -164,6 +171,10 @@ pub fn list(
     let effective_scope = effective_read_scope(scope);
     let preset_dirs = dirs::get_preset_dirs_scoped(effective_scope)?;
 
+    if !json && max_width > u16::MAX as usize {
+        anyhow::bail!("--max-width must be <= {}", u16::MAX);
+    }
+
     // Load default preset to highlight it
     let default_preset = settings_loader::resolve_default_preset(effective_scope)
         .ok()
@@ -188,12 +199,17 @@ pub fn list(
             Scope::Project => "project",
             Scope::User => "user",
             Scope::Auto => {
-                // For Auto scope, first dir is project (if it exists), second is user
-                if dir_index == 0 { "project" } else { "user" }
+                // For Auto scope, the user dir is always last; project (if present) comes before it.
+                let user_dir_index = preset_dirs.len().saturating_sub(1);
+                if dir_index == user_dir_index {
+                    "user"
+                } else {
+                    "project"
+                }
             }
         };
 
-        if !scopes_used.contains(&scope_label.to_string()) {
+        if !scopes_used.iter().any(|s| s == scope_label) {
             scopes_used.push(scope_label.to_string());
         }
 
@@ -212,18 +228,34 @@ pub fn list(
 
                             all_items.push(PresetListItem {
                                 name: preset_obj.name.clone(),
-                                description: preset_obj.description.clone(),
-                                filepath: Some(path.display().to_string()),
+                                description: should_include_json_field(
+                                    &validated_fields,
+                                    "description",
+                                )
+                                .then(|| preset_obj.description.clone())
+                                .flatten(),
+                                filepath: should_include_json_field(&validated_fields, "filepath")
+                                    .then(|| path.display().to_string()),
                                 scope: scope_label.to_string(),
                                 source: "file".to_string(),
                                 is_default,
-                                env_keys: preset_obj
-                                    .env
-                                    .as_ref()
-                                    .map(|e| e.keys().map(|k| k.to_string()).collect()),
-                                args: preset_obj.args.clone(),
-                                extends: preset_obj.extends.clone(),
-                                prompt: preset_obj.prompt.clone(),
+                                env_keys: should_include_json_field(&validated_fields, "env")
+                                    .then(|| {
+                                        preset_obj
+                                            .env
+                                            .as_ref()
+                                            .map(|e| e.keys().map(|k| k.to_string()).collect())
+                                    })
+                                    .flatten(),
+                                args: should_include_json_field(&validated_fields, "args")
+                                    .then(|| preset_obj.args.clone())
+                                    .flatten(),
+                                extends: should_include_json_field(&validated_fields, "extends")
+                                    .then(|| preset_obj.extends.clone())
+                                    .flatten(),
+                                prompt: should_include_json_field(&validated_fields, "prompt")
+                                    .then(|| preset_obj.prompt.clone())
+                                    .flatten(),
                             });
                         }
                     }
@@ -254,7 +286,7 @@ pub fn list(
             ),
         };
 
-        if !scopes_used.contains(&scope_label.to_string()) {
+        if !scopes_used.iter().any(|s| s == scope_label) {
             scopes_used.push(scope_label.to_string());
         }
 
@@ -262,18 +294,30 @@ pub fn list(
 
         all_items.push(PresetListItem {
             name: preset_obj.name.clone(),
-            description: preset_obj.description.clone(),
+            description: should_include_json_field(&validated_fields, "description")
+                .then(|| preset_obj.description.clone())
+                .flatten(),
             filepath: None,
             scope: scope_label.to_string(),
             source: "inline".to_string(),
             is_default,
-            env_keys: preset_obj
-                .env
-                .as_ref()
-                .map(|e| e.keys().map(|k| k.to_string()).collect()),
-            args: preset_obj.args.clone(),
-            extends: preset_obj.extends.clone(),
-            prompt: preset_obj.prompt.clone(),
+            env_keys: should_include_json_field(&validated_fields, "env")
+                .then(|| {
+                    preset_obj
+                        .env
+                        .as_ref()
+                        .map(|e| e.keys().map(|k| k.to_string()).collect())
+                })
+                .flatten(),
+            args: should_include_json_field(&validated_fields, "args")
+                .then(|| preset_obj.args.clone())
+                .flatten(),
+            extends: should_include_json_field(&validated_fields, "extends")
+                .then(|| preset_obj.extends.clone())
+                .flatten(),
+            prompt: should_include_json_field(&validated_fields, "prompt")
+                .then(|| preset_obj.prompt.clone())
+                .flatten(),
         });
     }
 
@@ -289,6 +333,7 @@ pub fn list(
     } else {
         // Table output
         let display_fields = get_display_fields(&validated_fields);
+        let show_default_legend = display_fields.iter().any(|f| f == "name");
 
         // Group items by scope and source for display
         let mut default_was_rendered = false;
@@ -359,7 +404,7 @@ pub fn list(
 
             // Build rows
             for item in scope_items {
-                if item.is_default {
+                if show_default_legend && item.is_default {
                     default_was_rendered = true;
                 }
 
@@ -451,7 +496,7 @@ pub fn list(
             table.set_header(headers);
 
             for item in inline_items {
-                if item.is_default {
+                if show_default_legend && item.is_default {
                     default_was_rendered = true;
                 }
 
@@ -484,7 +529,7 @@ pub fn list(
         }
 
         // Print legend if default preset was shown
-        if default_was_rendered {
+        if show_default_legend && default_was_rendered {
             println!("* indicates default preset");
         }
 

--- a/crates/claudio/src/commands/list.rs
+++ b/crates/claudio/src/commands/list.rs
@@ -327,7 +327,8 @@ pub fn list(
             scopes: scopes_used,
             invalid_files,
         };
-        println!("{}", serde_json::to_string_pretty(&output)?);
+        serde_json::to_writer_pretty(std::io::stdout(), &output)?;
+        println!();
     } else {
         // Table output
         let display_fields = get_display_fields(&validated_fields);

--- a/crates/claudio/src/commands/list.rs
+++ b/crates/claudio/src/commands/list.rs
@@ -1,6 +1,5 @@
 use crate::color::ColorConfig;
 use anyhow::Result;
-use claudio_core::preset::types::Preset;
 use claudio_core::preset::{dirs, io};
 use claudio_core::scope::Scope;
 use claudio_core::settings::loader as settings_loader;
@@ -115,18 +114,17 @@ fn get_display_fields<'a>(validated_fields: &'a Option<Vec<String>>) -> Cow<'a, 
 }
 
 fn build_row(
-    preset: &Preset,
+    item: &PresetListItem,
     filepath_display: &str,
     fields: &[String],
     default_preset: Option<&str>,
     color_config: &ColorConfig,
-    env_keys: Option<&[String]>,
 ) -> Vec<Cell> {
     fields
         .iter()
         .map(|field| match field.as_str() {
             "name" => {
-                let name = &preset.name;
+                let name = &item.name;
                 let display_name = if Some(name.as_str()) == default_preset {
                     format!("* {}", name)
                 } else {
@@ -142,16 +140,12 @@ fn build_row(
             }
             field_name => {
                 let value = match field_name {
-                    "description" => preset.description.as_deref().unwrap_or("").to_string(),
+                    "description" => item.description.as_deref().unwrap_or("").to_string(),
                     "filepath" => filepath_display.to_string(),
-                    "env" => env_keys.map(|keys| keys.join(", ")).unwrap_or_default(),
-                    "args" => preset
-                        .args
-                        .as_ref()
-                        .map(|a| a.join(", "))
-                        .unwrap_or_default(),
-                    "extends" => preset.extends.as_deref().unwrap_or("none").to_string(),
-                    "prompt" => preset.prompt.as_deref().unwrap_or("").to_string(),
+                    "env" => String::new(),
+                    "args" => item.args.as_ref().map(|a| a.join(", ")).unwrap_or_default(),
+                    "extends" => item.extends.as_deref().unwrap_or("none").to_string(),
+                    "prompt" => item.prompt.as_deref().unwrap_or("").to_string(),
                     _ => String::new(),
                 };
                 Cell::new(value).set_alignment(CellAlignment::Left)
@@ -411,26 +405,13 @@ pub fn list(
                     default_was_rendered = true;
                 }
 
-                // Convert PresetListItem back to Preset for build_row
-                let preset_obj = Preset {
-                    name: item.name.clone(),
-                    description: item.description.clone(),
-                    env: None, // Will use env_keys from item
-                    args: item.args.clone(),
-                    extends: item.extends.clone(),
-                    prompt: item.prompt.clone(),
-                    settings: None,
-                };
-
                 let filepath_display = item.filepath.as_deref().unwrap_or("");
-                let env_keys_slice = item.env_keys.as_deref();
                 let row = build_row(
-                    &preset_obj,
+                    item,
                     filepath_display,
                     &display_fields,
                     default_preset.as_deref(),
                     color_config,
-                    env_keys_slice,
                 );
                 table.add_row(row);
             }
@@ -503,24 +484,12 @@ pub fn list(
                     default_was_rendered = true;
                 }
 
-                let preset_obj = Preset {
-                    name: item.name.clone(),
-                    description: item.description.clone(),
-                    env: None,
-                    args: item.args.clone(),
-                    extends: item.extends.clone(),
-                    prompt: item.prompt.clone(),
-                    settings: None,
-                };
-
-                let env_keys_slice = item.env_keys.as_deref();
                 let row = build_row(
-                    &preset_obj,
+                    item,
                     "(inline)",
                     &display_fields,
                     default_preset.as_deref(),
                     color_config,
-                    env_keys_slice,
                 );
                 table.add_row(row);
             }

--- a/crates/claudio/src/commands/list.rs
+++ b/crates/claudio/src/commands/list.rs
@@ -320,6 +320,7 @@ pub fn list(
 
     // Output based on format
     if json {
+        all_items.sort_by(|a, b| a.scope.cmp(&b.scope).then(a.name.cmp(&b.name)));
         let output = PresetListOutput {
             items: all_items,
             default_preset,

--- a/crates/claudio/src/main.rs
+++ b/crates/claudio/src/main.rs
@@ -127,16 +127,16 @@ fn run(cli: Cli, color_config: ColorConfig) -> Result<ExitCode> {
             PresetCommands::List {
                 scope,
                 name,
-                verbose,
                 fields,
-                prompt_max_length,
+                max_width,
+                json,
             } => {
                 crate::commands::list::list(
                     scope.scope.into(),
                     name.as_deref(),
-                    *verbose,
                     fields.as_deref(),
-                    *prompt_max_length,
+                    *max_width,
+                    *json,
                     &color_config,
                 )?;
                 ExitCode::SUCCESS

--- a/crates/claudio/tests/test_cli.rs
+++ b/crates/claudio/tests/test_cli.rs
@@ -1044,3 +1044,131 @@ fn test_preset_list_json_output() {
         Some("test prompt")
     );
 }
+
+#[test]
+#[serial]
+fn test_preset_list_json_respects_fields() {
+    let env = TestEnvironment::new();
+    env.create_project_config();
+    env.create_user_config();
+
+    env.write_project_preset(
+        "project-preset",
+        r#"{
+  "name": "project-preset",
+  "description": "Project test preset",
+  "env": {
+    "TEST_VAR": "secret_value"
+  },
+  "args": ["--verbose"]
+}"#,
+    );
+
+    env.write_user_preset(
+        "user-preset",
+        r#"{
+  "name": "user-preset",
+  "description": "User test preset",
+  "env": {
+    "USER_VAR": "user_secret"
+  },
+  "prompt": "test prompt"
+}"#,
+    );
+
+    let output = run_claudio(
+        &env.project_dir,
+        &["preset", "list", "--json", "--fields", "name,filepath"],
+        &[(CLAUDIO_HOME_DIR_ENV_VAR, env.home_dir.to_str().unwrap())],
+    );
+
+    assert!(
+        output.status.success(),
+        "Preset list --json --fields command failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("Expected valid JSON output");
+
+    let items = json
+        .get("items")
+        .and_then(|v| v.as_array())
+        .expect("Expected items to be an array");
+
+    let project_preset = items
+        .iter()
+        .find(|item| item.get("name").and_then(|v| v.as_str()) == Some("project-preset"))
+        .expect("Expected to find project-preset in items");
+
+    // Only name + filepath should be present (plus metadata like scope/source/is_default).
+    assert!(project_preset.get("filepath").is_some());
+    assert!(project_preset.get("description").is_none());
+    assert!(project_preset.get("env_keys").is_none());
+    assert!(project_preset.get("args").is_none());
+    assert!(project_preset.get("prompt").is_none());
+}
+
+#[test]
+#[serial]
+fn test_preset_list_auto_scope_without_project_root_marks_user_scope() {
+    let env = TestEnvironment::new();
+    env.create_user_config();
+
+    env.write_user_preset(
+        "user-only",
+        r#"{
+  "name": "user-only",
+  "description": "User preset"
+}"#,
+    );
+
+    // Run from a directory without `.claudio/` or `.git/` so `Scope::Auto` resolves to user-only.
+    let output = run_claudio(
+        env.temp_dir.path(),
+        &["preset", "list", "--json"],
+        &[(CLAUDIO_HOME_DIR_ENV_VAR, env.home_dir.to_str().unwrap())],
+    );
+
+    assert!(
+        output.status.success(),
+        "Preset list --json command failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("Expected valid JSON output");
+
+    let items = json
+        .get("items")
+        .and_then(|v| v.as_array())
+        .expect("Expected items to be an array");
+
+    let user_preset = items
+        .iter()
+        .find(|item| item.get("name").and_then(|v| v.as_str()) == Some("user-only"))
+        .expect("Expected to find user-only in items");
+
+    assert_eq!(
+        user_preset.get("scope").and_then(|v| v.as_str()),
+        Some("user")
+    );
+
+    let scopes = json
+        .get("scopes")
+        .and_then(|v| v.as_array())
+        .expect("Expected scopes to be an array");
+
+    assert!(
+        scopes.iter().any(|s| s.as_str() == Some("user")),
+        "Expected 'user' in scopes"
+    );
+    assert!(
+        !scopes.iter().any(|s| s.as_str() == Some("project")),
+        "Did not expect 'project' in scopes"
+    );
+}

--- a/crates/claudio/tests/test_cli.rs
+++ b/crates/claudio/tests/test_cli.rs
@@ -837,3 +837,210 @@ fn test_init_force_dry_run_does_not_create_files() {
         stderr
     );
 }
+
+#[test]
+#[serial]
+fn test_preset_list_json_output() {
+    let env = TestEnvironment::new();
+    env.create_project_config();
+    env.create_user_config();
+
+    // Create test presets in both scopes
+    env.write_project_preset(
+        "project-preset",
+        r#"{
+  "name": "project-preset",
+  "description": "Project test preset",
+  "env": {
+    "TEST_VAR": "secret_value",
+    "ANOTHER_VAR": "another_secret"
+  },
+  "args": ["--verbose"],
+  "extends": null
+}"#,
+    );
+
+    env.write_user_preset(
+        "user-preset",
+        r#"{
+  "name": "user-preset",
+  "description": "User test preset",
+  "env": {
+    "USER_VAR": "user_secret"
+  },
+  "prompt": "test prompt"
+}"#,
+    );
+
+    // Set default preset
+    let settings_path = env.project_dir.join(".claudio").join("settings.json");
+    std::fs::write(
+        &settings_path,
+        r#"{
+  "default_preset": "project-preset",
+  "color": "cyan",
+  "no_color": false,
+  "require_preset": false,
+  "ignore_user_presets": false,
+  "dry_run_show_env": true,
+  "claude_executable": "claude",
+  "presets": []
+}"#,
+    )
+    .unwrap();
+
+    // Run preset list with --json flag
+    let output = run_claudio(
+        &env.project_dir,
+        &["preset", "list", "--json"],
+        &[(CLAUDIO_HOME_DIR_ENV_VAR, env.home_dir.to_str().unwrap())],
+    );
+
+    assert!(
+        output.status.success(),
+        "Preset list --json command failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Verify JSON output is valid
+    let json: Result<serde_json::Value, _> = serde_json::from_str(&stdout);
+    assert!(
+        json.is_ok(),
+        "Preset list JSON output is not valid JSON:\n{}",
+        stdout
+    );
+
+    let json_obj = json.unwrap();
+
+    // Verify top-level structure
+    assert!(
+        json_obj.get("items").is_some(),
+        "Expected 'items' field in JSON"
+    );
+    assert!(
+        json_obj.get("default_preset").is_some(),
+        "Expected 'default_preset' field in JSON"
+    );
+    assert!(
+        json_obj.get("scopes").is_some(),
+        "Expected 'scopes' field in JSON"
+    );
+    assert!(
+        json_obj.get("invalid_files").is_some(),
+        "Expected 'invalid_files' field in JSON"
+    );
+
+    // Verify default_preset is set correctly
+    assert_eq!(
+        json_obj.get("default_preset").and_then(|v| v.as_str()),
+        Some("project-preset"),
+        "Expected default_preset to be 'project-preset'"
+    );
+
+    // Verify items array
+    let items = json_obj
+        .get("items")
+        .and_then(|v| v.as_array())
+        .expect("Expected items to be an array");
+
+    assert!(
+        items.len() >= 2,
+        "Expected at least 2 presets (project and user)"
+    );
+
+    // Find project-preset in items
+    let project_preset = items
+        .iter()
+        .find(|item| item.get("name").and_then(|v| v.as_str()) == Some("project-preset"))
+        .expect("Expected to find project-preset in items");
+
+    // Verify project-preset fields
+    assert_eq!(
+        project_preset.get("description").and_then(|v| v.as_str()),
+        Some("Project test preset")
+    );
+    assert_eq!(
+        project_preset.get("scope").and_then(|v| v.as_str()),
+        Some("project")
+    );
+    assert_eq!(
+        project_preset.get("source").and_then(|v| v.as_str()),
+        Some("file")
+    );
+    assert_eq!(
+        project_preset.get("is_default").and_then(|v| v.as_bool()),
+        Some(true)
+    );
+
+    // Verify filepath is present
+    assert!(
+        project_preset.get("filepath").is_some(),
+        "Expected filepath to be present"
+    );
+
+    // CRITICAL: Verify env_keys are present but NOT env values (security check)
+    let env_keys = project_preset
+        .get("env_keys")
+        .and_then(|v| v.as_array())
+        .expect("Expected env_keys array");
+
+    assert!(
+        env_keys.iter().any(|k| k.as_str() == Some("TEST_VAR")),
+        "Expected TEST_VAR in env_keys"
+    );
+    assert!(
+        env_keys.iter().any(|k| k.as_str() == Some("ANOTHER_VAR")),
+        "Expected ANOTHER_VAR in env_keys"
+    );
+
+    // CRITICAL SECURITY CHECK: Ensure no env VALUES are leaked
+    let json_str = serde_json::to_string(&json_obj).unwrap();
+    assert!(
+        !json_str.contains("secret_value"),
+        "ERROR: Env value 'secret_value' leaked in JSON output"
+    );
+    assert!(
+        !json_str.contains("another_secret"),
+        "ERROR: Env value 'another_secret' leaked in JSON output"
+    );
+    assert!(
+        !json_str.contains("user_secret"),
+        "ERROR: Env value 'user_secret' leaked in JSON output"
+    );
+
+    // Verify args array
+    let args = project_preset
+        .get("args")
+        .and_then(|v| v.as_array())
+        .expect("Expected args array");
+    assert!(
+        args.iter().any(|a| a.as_str() == Some("--verbose")),
+        "Expected --verbose in args"
+    );
+
+    // Find user-preset in items
+    let user_preset = items
+        .iter()
+        .find(|item| item.get("name").and_then(|v| v.as_str()) == Some("user-preset"))
+        .expect("Expected to find user-preset in items");
+
+    // Verify user-preset fields
+    assert_eq!(
+        user_preset.get("scope").and_then(|v| v.as_str()),
+        Some("user")
+    );
+    assert_eq!(
+        user_preset.get("is_default").and_then(|v| v.as_bool()),
+        Some(false),
+        "User preset should NOT be marked as default"
+    );
+
+    // Verify prompt field is present for user-preset
+    assert_eq!(
+        user_preset.get("prompt").and_then(|v| v.as_str()),
+        Some("test prompt")
+    );
+}


### PR DESCRIPTION
Improves `claudio preset list` JSON output so `--fields` filters the emitted item fields, matching table behavior. Fixes incorrect scope labeling in Auto mode when no project root is detected and validates `--max-width` to avoid truncation. Updates docs and adds integration tests for the new behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/binado/claudio/pull/87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
